### PR TITLE
Close #9: Create a canvas wrapper with ability to draw a matrix data by palette

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,8 +17,11 @@ Added
 -----
 
 - ReactJS_ project skeleton.
-- ``App`` component.
-- ``index`` view.
+- ``index`` main view.
+- ``App`` container component with routing.
+- ``Home`` component for the homepage.
+- ``first/MatrixCanvas`` component
+  to visualize matrices based on provided palette.
 - ``main`` stylesheet.
 
 .. _Keep a Changelog:

--- a/package-lock.json
+++ b/package-lock.json
@@ -3211,6 +3211,12 @@
       "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
       "dev": true
     },
+    "cssfontparser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/cssfontparser/-/cssfontparser-1.2.1.tgz",
+      "integrity": "sha1-9AIvyPlwDGgCnVQghK+69CWj8+M=",
+      "dev": true
+    },
     "cssom": {
       "version": "0.3.8",
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
@@ -7191,6 +7197,16 @@
             "decamelize": "^1.2.0"
           }
         }
+      }
+    },
+    "jest-canvas-mock": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/jest-canvas-mock/-/jest-canvas-mock-2.1.0.tgz",
+      "integrity": "sha512-1yWLNr6xcmhmADLc5ITOYjXnNl2EWUDlXYpplYqgGdATgZaP8IBp241ihVIfrORM8AhuZW8PXRPdzWBEQOpjBQ==",
+      "dev": true,
+      "requires": {
+        "cssfontparser": "^1.2.1",
+        "parse-color": "^1.0.0"
       }
     },
     "jest-changed-files": {
@@ -13285,6 +13301,23 @@
         "evp_bytestokey": "^1.0.0",
         "pbkdf2": "^3.0.3",
         "safe-buffer": "^5.1.1"
+      }
+    },
+    "parse-color": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/parse-color/-/parse-color-1.0.0.tgz",
+      "integrity": "sha1-e3SLlag/A/FqlPU15S1/PZRlhhk=",
+      "dev": true,
+      "requires": {
+        "color-convert": "~0.5.0"
+      },
+      "dependencies": {
+        "color-convert": {
+          "version": "0.5.3",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz",
+          "integrity": "sha1-vbbGnOZg+t/+CwAHzER+G59ygr0=",
+          "dev": true
+        }
       }
     },
     "parse-entities": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
       "\\.css$": "<rootDir>/__mocks__/fileMock.js"
     },
     "setupFilesAfterEnv": [
-      "<rootDir>/test-setup.js",
+      "<rootDir>/test-setup.js"
+    ],
+    "setupFiles": [
       "jest-canvas-mock"
     ]
   },

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
       "\\.css$": "<rootDir>/__mocks__/fileMock.js"
     },
     "setupFilesAfterEnv": [
-      "<rootDir>/test-setup.js"
+      "<rootDir>/test-setup.js",
+      "jest-canvas-mock"
     ]
   },
   "repository": {
@@ -49,6 +50,7 @@
     "eslint-plugin-react": "^7.14.2",
     "html-webpack-plugin": "^3.2.0",
     "jest": "^24.8.0",
+    "jest-canvas-mock": "^2.1.0",
     "jest-enzyme": "^7.0.2",
     "mini-css-extract-plugin": "^0.7.0",
     "npm": "^6.10.1",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "mini-css-extract-plugin": "^0.7.0",
     "npm": "^6.10.1",
     "postcss-loader": "^3.0.0",
-    "prop-types": "^15.7.2",
     "react-router": "^5.0.1",
     "style-loader": "^0.23.1",
     "stylelint": "^10.1.0",
@@ -67,6 +66,7 @@
     "webpack-dev-server": "^3.7.2"
   },
   "dependencies": {
+    "prop-types": "^15.7.2",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "react-router-dom": "^5.0.1"

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "mini-css-extract-plugin": "^0.7.0",
     "npm": "^6.10.1",
     "postcss-loader": "^3.0.0",
+    "prop-types": "^15.7.2",
     "react-router": "^5.0.1",
     "style-loader": "^0.23.1",
     "stylelint": "^10.1.0",

--- a/src/components/first/MatrixCanvas.jsx
+++ b/src/components/first/MatrixCanvas.jsx
@@ -35,11 +35,9 @@ class MatrixCanvas extends React.Component {
       ]))).isRequired,
       width: PropTypes.number.isRequired,
       palette: PropTypes.oneOfType([
-        PropTypes.objectOf(PropTypes.oneOfType([
-          PropTypes.string,
-          PropTypes.func,
-        ])),
+        PropTypes.objectOf(PropTypes.string),
         PropTypes.arrayOf(PropTypes.string),
+        PropTypes.func,
       ]),
     };
   }

--- a/src/components/first/MatrixCanvas.jsx
+++ b/src/components/first/MatrixCanvas.jsx
@@ -21,6 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+import assert from 'assert';
 import React from 'react';
 import PropTypes from 'prop-types';
 
@@ -33,13 +34,19 @@ class MatrixCanvas extends React.Component {
         PropTypes.string,
       ]))).isRequired,
       width: PropTypes.number.isRequired,
-      palette: PropTypes.objectOf(PropTypes.string),
+      palette: PropTypes.oneOfType([
+        PropTypes.objectOf(PropTypes.oneOfType([
+          PropTypes.string,
+          PropTypes.func,
+        ])),
+        PropTypes.arrayOf(PropTypes.string),
+      ]),
     };
   }
 
   static get defaultProps() {
     return {
-      palette: null,
+      palette: color => color,
     };
   }
 
@@ -61,10 +68,12 @@ class MatrixCanvas extends React.Component {
     const originalFillStyle = ctx.fillStyle;
     for (let y = 0; y < matrix.length; y += 1) {
       for (let x = 0; x < matrix[y].length; x += 1) {
-        if (palette) {
+        if (palette instanceof Function) {
+          ctx.fillStyle = palette(matrix[y][x]);
+        } else if (palette instanceof Object && palette !== null) {
           ctx.fillStyle = palette[matrix[y][x]];
         } else {
-          ctx.fillStyle = matrix[y][x];
+          assert(false, `Unsupported palette type ${typeof palette}`);
         }
         ctx.fillRect(
           Math.floor(x * blockWidth),

--- a/src/components/first/MatrixCanvas.jsx
+++ b/src/components/first/MatrixCanvas.jsx
@@ -1,0 +1,94 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2019 char-lie
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+
+class MatrixCanvas extends React.Component {
+  static get propTypes() {
+    return {
+      height: PropTypes.number.isRequired,
+      matrix: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.oneOfType([
+        PropTypes.number,
+        PropTypes.string,
+      ]))).isRequired,
+      width: PropTypes.number.isRequired,
+      palette: PropTypes.objectOf(PropTypes.string),
+    };
+  }
+
+  static get defaultProps() {
+    return {
+      palette: null,
+    };
+  }
+
+  componentDidMount() {
+    const { matrix } = this.props;
+    this.draw(matrix);
+  }
+
+  componentDidUpdate() {
+    const { matrix } = this.props;
+    this.draw(matrix);
+  }
+
+  draw(matrix) {
+    const { height, width, palette } = this.props;
+    const blockHeight = height / matrix.length;
+    const blockWidth = width / matrix[0].length;
+    const ctx = this.canvas.getContext('2d');
+    const originalFillStyle = ctx.fillStyle;
+    for (let y = 0; y < matrix.length; y += 1) {
+      for (let x = 0; x < matrix[y].length; x += 1) {
+        if (palette) {
+          ctx.fillStyle = palette[matrix[y][x]];
+        } else {
+          ctx.fillStyle = matrix[y][x];
+        }
+        ctx.fillRect(
+          Math.floor(x * blockWidth),
+          Math.floor(y * blockHeight),
+          Math.ceil(blockWidth),
+          Math.ceil(blockHeight),
+        );
+      }
+    }
+    ctx.fillStyle = originalFillStyle;
+  }
+
+  render() {
+    const { height, width } = this.props;
+    return (
+      <div>
+        <canvas
+          ref={(component) => { this.canvas = component; }}
+          width={width}
+          height={height}
+        />
+      </div>
+    );
+  }
+}
+
+export default MatrixCanvas;

--- a/src/components/first/MatrixCanvas.jsx
+++ b/src/components/first/MatrixCanvas.jsx
@@ -25,6 +25,17 @@ import assert from 'assert';
 import React from 'react';
 import PropTypes from 'prop-types';
 
+/**
+ * @param width in pixels
+ * @param height in pixels
+ * @param palette optional object, array or function with color palette:
+ *   - default is the identity function to use a matrix with colors;
+ *   - you can provide an object or array to map color identifiers to colors;
+ *   - you can also provide the mapping via a function.
+ * @param matrix with colors
+ *   - strings with RGB colors in CSS format with hash
+ *   - numbers with indices of colors from the palette
+ */
 class MatrixCanvas extends React.Component {
   static get propTypes() {
     return {

--- a/src/components/first/MatrixCanvas.jsx
+++ b/src/components/first/MatrixCanvas.jsx
@@ -69,6 +69,11 @@ class MatrixCanvas extends React.Component {
         if (palette instanceof Function) {
           ctx.fillStyle = palette(matrix[y][x]);
         } else if (palette instanceof Object && palette !== null) {
+          if (!(matrix[y][x] in palette)) {
+            throw RangeError(
+              `Key ${matrix[y][x]} does not exist in palette ${palette}`,
+            );
+          }
           ctx.fillStyle = palette[matrix[y][x]];
         } else {
           assert(false, `Unsupported palette type ${typeof palette}`);

--- a/src/components/first/MatrixCanvas.jsx
+++ b/src/components/first/MatrixCanvas.jsx
@@ -69,6 +69,11 @@ class MatrixCanvas extends React.Component {
     this.draw(matrix);
   }
 
+  /**
+   * Virtually split canvas by a grid
+   * represented by a matrix.
+   * Each cell of grid is filled with the color specified in the matrix.
+   */
   draw(matrix) {
     const { height, width, palette } = this.props;
     const blockHeight = height / matrix.length;

--- a/src/components/first/MatrixCanvas.test.jsx
+++ b/src/components/first/MatrixCanvas.test.jsx
@@ -1,0 +1,41 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2019 char-lie
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+import React from 'react';
+import { mount } from 'enzyme';
+import { shallowToJson } from 'enzyme-to-json';
+
+import MatrixCanvas from './MatrixCanvas';
+
+describe('MatrixCanvas', () => {
+  it('should render correctly', () => {
+    const wrapper = mount(
+      <MatrixCanvas
+        width={10}
+        height={20}
+        matrix={[[0, 1, 2], [3, 4, 5]]}
+      />,
+    );
+    expect(shallowToJson(wrapper)).toMatchSnapshot();
+  });
+});

--- a/src/components/first/__snapshots__/MatrixCanvas.test.jsx.snap
+++ b/src/components/first/__snapshots__/MatrixCanvas.test.jsx.snap
@@ -1,0 +1,30 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`MatrixCanvas should render correctly 1`] = `
+<MatrixCanvas
+  height={20}
+  matrix={
+    Array [
+      Array [
+        0,
+        1,
+        2,
+      ],
+      Array [
+        3,
+        4,
+        5,
+      ],
+    ]
+  }
+  palette={[Function]}
+  width={10}
+>
+  <div>
+    <canvas
+      height={20}
+      width={10}
+    />
+  </div>
+</MatrixCanvas>
+`;


### PR DESCRIPTION
- Implement `MatrixCanvas` component to draw images contained in matrices, using a specified color palette or using colors directly from the matrix.
- Use `prop-types` to validate fields of the component.
- Use `jest-canvas-mock` to avoid errors during `canvas` testing.
- Need to handle errors of components correctly https://reactjs.org/docs/error-boundaries.html