### PR TITLE
Close #21: Host on Heroku

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,10 @@
       "@babel/preset-react"
     ]
   },
+  "engines": {
+    "node": "^12",
+    "npm": "^6"
+  },
   "jest": {
     "moduleNameMapper": {
       "\\.css$": "<rootDir>/__mocks__/fileMock.js"


### PR DESCRIPTION
- Specify NodeJS 12 and NPM 6 versions in `engines` section of `package.json`
  https://devcenter.heroku.com/articles/nodejs-support
- Works well without `Procfile`
  https://devcenter.heroku.com/articles/procfile