### PR TITLE
Close #37: Split task 1 into two separate ones

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,15 +24,12 @@ Added
   - ``index`` main view.
   - ``App`` container component with routing.
   - ``Home`` component for the homepage.
-  - ``zero/Zero`` component for the test practicum (practicum zero).
-  - ``first/First`` container component for the first practicum.
-  - ``first/FirstA`` container component
-    with the task ``A`` of the first practicum.
-  - ``first/FirstB`` container component
-    with the task ``B`` of the first practicum.
-  - ``first/MatrixCanvas`` component
+  - ``Zero`` component for the test practicum (practicum zero).
+  - ``First`` component with the first practicum.
+  - ``Second`` component with the second practicum.
+  - ``MatrixCanvas`` component
     to visualize matrices based on provided palette.
-  - ``first/AnimationCanvas`` component
+  - ``AnimationCanvas`` component
     to visualize and animate ``AnimationSprite`` instances.
   - ``AnimationSprite`` class
     to store information about animating sprites.

--- a/package-lock.json
+++ b/package-lock.json
@@ -11582,9 +11582,9 @@
       }
     },
     "npm": {
-      "version": "6.10.3",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-6.10.3.tgz",
-      "integrity": "sha512-AH2uhSRaIMll7xz1JuLA6XbZu5k6DMSc77U6uWfuyBch4EzwpEc5dd54/OsX4Njioi7fSL7YmuPQbqKE2qiklw==",
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-6.11.1.tgz",
+      "integrity": "sha512-ckV89fITMaOMa1UAbOEvGHtepWhCrlG34fGvr/K4UbD6LiS8Vv85uftpNqK6bbvej9lsXg5MPuFfuq88W91qyA==",
       "dev": true,
       "requires": {
         "JSONStream": "^1.3.5",
@@ -11593,16 +11593,16 @@
         "ansistyles": "~0.1.3",
         "aproba": "^2.0.0",
         "archy": "~1.0.0",
-        "bin-links": "^1.1.2",
+        "bin-links": "^1.1.3",
         "bluebird": "^3.5.5",
         "byte-size": "^5.0.1",
-        "cacache": "^12.0.2",
+        "cacache": "^12.0.3",
         "call-limit": "^1.1.1",
         "chownr": "^1.1.2",
         "ci-info": "^2.0.0",
         "cli-columns": "^3.1.2",
         "cli-table3": "^0.5.1",
-        "cmd-shim": "~2.0.2",
+        "cmd-shim": "^3.0.2",
         "columnify": "~1.5.4",
         "config-chain": "^1.1.12",
         "debuglog": "*",
@@ -11614,9 +11614,9 @@
         "find-npm-prefix": "^1.0.2",
         "fs-vacuum": "~1.2.10",
         "fs-write-stream-atomic": "~1.0.10",
-        "gentle-fs": "^2.0.1",
+        "gentle-fs": "^2.2.1",
         "glob": "^7.1.4",
-        "graceful-fs": "^4.2.0",
+        "graceful-fs": "^4.2.2",
         "has-unicode": "~2.0.1",
         "hosted-git-info": "^2.8.2",
         "iferr": "^1.0.2",
@@ -11629,7 +11629,7 @@
         "is-cidr": "^3.0.0",
         "json-parse-better-errors": "^1.0.2",
         "lazy-property": "~1.0.0",
-        "libcipm": "^4.0.0",
+        "libcipm": "^4.0.3",
         "libnpm": "^3.0.1",
         "libnpmaccess": "^3.0.2",
         "libnpmhook": "^5.0.3",
@@ -11661,10 +11661,10 @@
         "npm-audit-report": "^1.3.2",
         "npm-cache-filename": "~1.0.2",
         "npm-install-checks": "~3.0.0",
-        "npm-lifecycle": "^3.1.2",
+        "npm-lifecycle": "^3.1.3",
         "npm-package-arg": "^6.1.0",
         "npm-packlist": "^1.4.4",
-        "npm-pick-manifest": "^2.2.3",
+        "npm-pick-manifest": "^3.0.0",
         "npm-profile": "^4.0.2",
         "npm-registry-fetch": "^4.0.0",
         "npm-user-validate": "~1.0.0",
@@ -11672,16 +11672,16 @@
         "once": "~1.4.0",
         "opener": "^1.5.1",
         "osenv": "^0.1.5",
-        "pacote": "^9.5.4",
+        "pacote": "^9.5.8",
         "path-is-inside": "~1.0.2",
         "promise-inflight": "~1.0.1",
         "qrcode-terminal": "^0.12.0",
         "query-string": "^6.8.2",
         "qw": "~1.0.1",
         "read": "~1.0.7",
-        "read-cmd-shim": "~1.0.1",
+        "read-cmd-shim": "^1.0.3",
         "read-installed": "~4.0.3",
-        "read-package-json": "^2.0.13",
+        "read-package-json": "^2.1.0",
         "read-package-tree": "^5.3.1",
         "readable-stream": "^3.4.0",
         "readdir-scoped-modules": "^1.1.0",
@@ -11689,7 +11689,7 @@
         "retry": "^0.12.0",
         "rimraf": "^2.6.3",
         "safe-buffer": "^5.1.2",
-        "semver": "^5.7.0",
+        "semver": "^5.7.1",
         "sha": "^3.0.0",
         "slide": "~1.1.6",
         "sorted-object": "~2.0.1",
@@ -11875,14 +11875,14 @@
           }
         },
         "bin-links": {
-          "version": "1.1.2",
+          "version": "1.1.3",
           "bundled": true,
           "dev": true,
           "requires": {
-            "bluebird": "^3.5.0",
-            "cmd-shim": "^2.0.2",
-            "gentle-fs": "^2.0.0",
-            "graceful-fs": "^4.1.11",
+            "bluebird": "^3.5.3",
+            "cmd-shim": "^3.0.0",
+            "gentle-fs": "^2.0.1",
+            "graceful-fs": "^4.1.15",
             "write-file-atomic": "^2.3.0"
           }
         },
@@ -11935,7 +11935,7 @@
           "dev": true
         },
         "cacache": {
-          "version": "12.0.2",
+          "version": "12.0.3",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -12059,7 +12059,7 @@
           "dev": true
         },
         "cmd-shim": {
-          "version": "2.0.2",
+          "version": "3.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -12730,14 +12730,16 @@
           "dev": true
         },
         "gentle-fs": {
-          "version": "2.0.1",
+          "version": "2.2.1",
           "bundled": true,
           "dev": true,
           "requires": {
             "aproba": "^1.1.2",
+            "chownr": "^1.1.2",
             "fs-vacuum": "^1.2.10",
             "graceful-fs": "^4.1.11",
             "iferr": "^0.1.5",
+            "infer-owner": "^1.0.4",
             "mkdirp": "^0.5.1",
             "path-is-inside": "^1.0.2",
             "read-cmd-shim": "^1.0.1",
@@ -12824,7 +12826,7 @@
           }
         },
         "graceful-fs": {
-          "version": "4.2.0",
+          "version": "4.2.2",
           "bundled": true,
           "dev": true
         },
@@ -13182,7 +13184,7 @@
           }
         },
         "libcipm": {
-          "version": "4.0.0",
+          "version": "4.0.3",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -13726,7 +13728,7 @@
           }
         },
         "npm-lifecycle": {
-          "version": "3.1.2",
+          "version": "3.1.3",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -13766,7 +13768,7 @@
           }
         },
         "npm-pick-manifest": {
-          "version": "2.2.3",
+          "version": "3.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -13931,15 +13933,17 @@
           }
         },
         "pacote": {
-          "version": "9.5.4",
+          "version": "9.5.8",
           "bundled": true,
           "dev": true,
           "requires": {
             "bluebird": "^3.5.3",
-            "cacache": "^12.0.0",
+            "cacache": "^12.0.2",
+            "chownr": "^1.1.2",
             "figgy-pudding": "^3.5.1",
             "get-stream": "^4.1.0",
             "glob": "^7.1.3",
+            "infer-owner": "^1.0.4",
             "lru-cache": "^5.1.1",
             "make-fetch-happen": "^5.0.0",
             "minimatch": "^3.0.4",
@@ -13949,7 +13953,7 @@
             "normalize-package-data": "^2.4.0",
             "npm-package-arg": "^6.1.0",
             "npm-packlist": "^1.1.12",
-            "npm-pick-manifest": "^2.2.3",
+            "npm-pick-manifest": "^3.0.0",
             "npm-registry-fetch": "^4.0.0",
             "osenv": "^0.1.5",
             "promise-inflight": "^1.0.1",
@@ -13959,7 +13963,7 @@
             "safe-buffer": "^5.1.2",
             "semver": "^5.6.0",
             "ssri": "^6.0.1",
-            "tar": "^4.4.8",
+            "tar": "^4.4.10",
             "unique-filename": "^1.1.1",
             "which": "^1.3.1"
           },
@@ -14198,7 +14202,7 @@
           }
         },
         "read-cmd-shim": {
-          "version": "1.0.1",
+          "version": "1.0.3",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -14220,7 +14224,7 @@
           }
         },
         "read-package-json": {
-          "version": "2.0.13",
+          "version": "2.1.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -14360,7 +14364,7 @@
           "dev": true
         },
         "semver": {
-          "version": "5.7.0",
+          "version": "5.7.1",
           "bundled": true,
           "dev": true
         },

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "jest-canvas-mock": "^2.1.1",
     "jest-enzyme": "^7.1.0",
     "mini-css-extract-plugin": "^0.8.0",
-    "npm": "^6.10.3",
+    "npm": "^6.11.1",
     "npm-check-updates": "^3.1.21",
     "postcss-loader": "^3.0.0",
     "react-router": "^5.0.1",

--- a/src/components/AnimationCanvas.jsx
+++ b/src/components/AnimationCanvas.jsx
@@ -1,0 +1,96 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2019 char-lie
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+
+import AnimationSprite from '../scripts/AnimationSprite';
+import drawMatrix from '../scripts/drawMatrix';
+
+/**
+ * @param width in pixels
+ * @param height in pixels
+ * @param sprites with AnimationSprite instances to render and animate
+ */
+class AnimationCanvas extends Component {
+  componentDidMount() {
+    window.requestAnimationFrame(() => this.animation());
+  }
+
+  animation() {
+    const {
+      height,
+      sprites,
+      width,
+      updateSprites,
+    } = this.props;
+
+    const time = new Date();
+    const context = this.canvas.getContext('2d');
+    context.clearRect(0, 0, width, height);
+
+    sprites.filter(
+      (sprite) => !sprite.needDestroy(time) && sprite.visible(time),
+    ).forEach((sprite) => {
+      drawMatrix({
+        context,
+        matrix: sprite.image(time),
+        offsetX: sprite.offsetX(time),
+        offsetY: sprite.offsetY(time),
+        palette: sprite.palette,
+        scaleX: sprite.scale(time),
+        scaleY: sprite.scale(time),
+      });
+    });
+
+    updateSprites(time);
+    window.requestAnimationFrame(() => this.animation());
+  }
+
+  render() {
+    const { height, width } = this.props;
+    return (
+      <div>
+        <canvas
+          ref={(component) => { this.canvas = component; }}
+          width={width}
+          height={height}
+        />
+      </div>
+    );
+  }
+}
+
+AnimationCanvas.propTypes = {
+  height: PropTypes.number.isRequired,
+  sprites: PropTypes.arrayOf(PropTypes.instanceOf(AnimationSprite)),
+  width: PropTypes.number.isRequired,
+  updateSprites: PropTypes.func,
+};
+
+AnimationCanvas.defaultProps = {
+  sprites: [],
+  updateSprites: () => {},
+};
+
+export default AnimationCanvas;

--- a/src/components/App.test.jsx
+++ b/src/components/App.test.jsx
@@ -28,7 +28,8 @@ import { shallowToJson } from 'enzyme-to-json';
 
 import App from './App';
 import Home from './Home';
-import First from './first/First';
+import First from './First';
+import Second from './Second';
 
 describe('App', () => {
   it('should render correctly', () => {
@@ -42,6 +43,7 @@ describe('App', () => {
     );
     expect(wrapper).toContainExactlyOneMatchingElement(Home);
     expect(wrapper).not.toContainMatchingElement(First);
+    expect(wrapper).not.toContainMatchingElement(Second);
   });
   it('should show the first task page on /first', () => {
     const wrapper = mount(
@@ -50,6 +52,17 @@ describe('App', () => {
       </MemoryRouter>,
     );
     expect(wrapper).toContainExactlyOneMatchingElement(First);
+    expect(wrapper).not.toContainMatchingElement(Second);
+    expect(wrapper).not.toContainMatchingElement(Home);
+  });
+  it('should show the second task page on /second', () => {
+    const wrapper = mount(
+      <MemoryRouter initialEntries={['/second']}>
+        <App />
+      </MemoryRouter>,
+    );
+    expect(wrapper).toContainExactlyOneMatchingElement(Second);
+    expect(wrapper).not.toContainMatchingElement(First);
     expect(wrapper).not.toContainMatchingElement(Home);
   });
 });

--- a/src/components/First.jsx
+++ b/src/components/First.jsx
@@ -1,0 +1,300 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2019 char-lie
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+import React, { Component } from 'react';
+
+import MatrixCanvas from './MatrixCanvas';
+
+/**
+ * The component consists of the three main parts:
+ * - Header
+ * - Control panel
+ * - Image
+ *
+ * The header contains only text.
+ *
+ * The image is a MatrixCanvas component with current noised digit image.
+ * We use binary matrices from First.IDEAL_NUMBERS to represent the image.
+ *
+ * Control panel contains inputs to change
+ * - Image width multiplier (First.changeWidth)
+ * - Image height multiplier (First.changeHeight)
+ * - Change noise level (First.changeNoiseLevel)
+ * - Generate new image (First.generateMatrix)
+ *
+ * The noise level is a probability of generated random variable
+ * to be equal `1`.
+ * Otherwise, it's `0`.
+ * A random number is generated independently for each pixel.
+ * Then it's xor-ed with the matrix value.
+ */
+class First extends Component {
+  /**
+   * Binary matrices of size 5x3 (5 rows, 3 columns),
+   * representing digits from `0` to `9`.
+   */
+  static IDEAL_NUMBERS = [
+    [
+      [1, 1, 1],
+      [1, 0, 1],
+      [1, 0, 1],
+      [1, 0, 1],
+      [1, 1, 1],
+    ],
+    [
+      [0, 1, 0],
+      [0, 1, 0],
+      [0, 1, 0],
+      [0, 1, 0],
+      [0, 1, 0],
+    ],
+    [
+      [1, 1, 1],
+      [0, 0, 1],
+      [1, 1, 1],
+      [1, 0, 0],
+      [1, 1, 1],
+    ],
+    [
+      [1, 1, 1],
+      [0, 0, 1],
+      [1, 1, 1],
+      [0, 0, 1],
+      [1, 1, 1],
+    ],
+    [
+      [1, 0, 1],
+      [1, 0, 1],
+      [1, 1, 1],
+      [0, 0, 1],
+      [0, 0, 1],
+    ],
+    [
+      [1, 1, 1],
+      [1, 0, 0],
+      [1, 1, 1],
+      [0, 0, 1],
+      [1, 1, 1],
+    ],
+    [
+      [1, 1, 1],
+      [1, 0, 0],
+      [1, 1, 1],
+      [1, 0, 1],
+      [1, 1, 1],
+    ],
+    [
+      [1, 1, 1],
+      [0, 0, 1],
+      [0, 1, 0],
+      [1, 0, 0],
+      [1, 0, 0],
+    ],
+    [
+      [1, 1, 1],
+      [1, 0, 1],
+      [1, 1, 1],
+      [1, 0, 1],
+      [1, 1, 1],
+    ],
+    [
+      [1, 1, 1],
+      [1, 0, 1],
+      [1, 1, 1],
+      [0, 0, 1],
+      [0, 0, 1],
+    ],
+  ];
+
+  /**
+   * Default canvas width.
+   */
+  static WIDTH = 300;
+
+  /**
+   * Default canvas height.
+   */
+  static HEIGHT = 500;
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      matrix: [[0]],
+      width: 1,
+      height: 1,
+      noiseLevel: 0,
+    };
+  }
+
+  /**
+   * Change image height multiplier.
+   * The height is a positive integer.
+   */
+  changeHeight(inputHeight) {
+    let height = Number(inputHeight);
+    if (height < 1) {
+      height = 1;
+    }
+    height = Math.round(height);
+    this.setState((previousState) => ({
+      ...previousState,
+      height,
+    }));
+  }
+
+  /**
+   * Change the probability of Bernoulli random variable
+   * infered in First.applyElementNoise.
+   */
+  changeNoiseLevel(inputNoiseLevel) {
+    let noiseLevel = Number(inputNoiseLevel);
+    if (noiseLevel < 0) {
+      noiseLevel = 0;
+    } else if (noiseLevel > 1) {
+      noiseLevel = 1;
+    }
+    this.setState((previousState) => ({
+      ...previousState,
+      noiseLevel,
+    }));
+  }
+
+  /**
+   * Change image width multiplier.
+   * The width is a positive integer.
+   */
+  changeWidth(inputWidth) {
+    let width = Number(inputWidth);
+    if (width < 1) {
+      width = 1;
+    }
+    width = Math.round(width);
+    this.setState((previousState) => ({
+      ...previousState,
+      width,
+    }));
+  }
+
+  /**
+   * Apply Bernoulli noise to the value and return the new one.
+   */
+  applyElementNoise(value) {
+    const { noiseLevel } = this.state;
+    /* eslint-disable-next-line no-bitwise */
+    return value ^ (Math.random() < noiseLevel);
+  }
+
+  /**
+   * Generate new matrix.
+   * First, one of the First.IDEAL_NUMBERS elements is chosen
+   * as the initial value.
+   * First.state.width is used to duplicate columns of the reference.
+   * First.state.height is used to duplicate rows of the reference.
+   * Then, we add a noise to the matrix
+   * by xoring each element with random values generated by Bernoulli law.
+   */
+  generateMatrix() {
+    const { width, height } = this.state;
+    const index = Math.floor(Math.random() * First.IDEAL_NUMBERS.length);
+    const idealDigit = First.IDEAL_NUMBERS[index];
+    const matrix = [];
+
+    idealDigit.forEach((row, i) => {
+      for (let h = 0; h < height; h += 1) {
+        matrix.push([]);
+        for (let j = 0; j < row.length; j += 1) {
+          for (let w = 0; w < width; w += 1) {
+            matrix[i * height + h].push(
+              this.applyElementNoise(First.IDEAL_NUMBERS[index][i][j]),
+            );
+          }
+        }
+      }
+    });
+
+    this.setState((previousState) => ({
+      ...previousState,
+      matrix,
+    }));
+  }
+
+  render() {
+    const {
+      matrix,
+      width,
+      height,
+      noiseLevel,
+    } = this.state;
+    return (
+      <div>
+        <h3>Task A</h3>
+        <form>
+          <label htmlFor={this.widthInput}>
+            Width:
+            <input
+              ref={(component) => { this.widthInput = component; }}
+              type="number"
+              value={width}
+              step={1}
+              onChange={(event) => this.changeWidth(event.target.value)}
+            />
+          </label>
+          <label htmlFor={this.heightInput}>
+            Height:
+            <input
+              ref={(component) => { this.heightInput = component; }}
+              type="number"
+              value={height}
+              step={1}
+              onChange={(event) => this.changeHeight(event.target.value)}
+            />
+          </label>
+          <label htmlFor={this.noiseLevelInput}>
+            Noise level:
+            <input
+              ref={(component) => { this.noiseLevelInput = component; }}
+              type="number"
+              value={noiseLevel}
+              step={0.1}
+              onChange={(event) => this.changeNoiseLevel(event.target.value)}
+            />
+          </label>
+          <button type="button" onClick={() => this.generateMatrix()}>
+            Next
+          </button>
+        </form>
+        <MatrixCanvas
+          height={Math.round(First.HEIGHT)}
+          width={Math.round(First.WIDTH)}
+          matrix={matrix}
+          palette={{
+            0: '#FFFFFF',
+            1: '#000000',
+          }}
+        />
+      </div>
+    );
+  }
+}
+
+export default First;

--- a/src/components/First.test.jsx
+++ b/src/components/First.test.jsx
@@ -22,48 +22,13 @@
  * SOFTWARE.
  */
 import React from 'react';
-import {
-  Link,
-  Route,
-  Switch,
-} from 'react-router-dom';
+import { shallow } from 'enzyme';
+import { shallowToJson } from 'enzyme-to-json';
 
-import Zero from './Zero';
 import First from './First';
-import Second from './Second';
-import Home from './Home';
 
-const App = () => (
-  <div>
-    <nav>
-      <Link to="/">Home</Link>
-      <Link to="/zero">Zero</Link>
-      <Link to="/first">First</Link>
-      <Link to="/second">Second</Link>
-    </nav>
-    <Switch>
-      <Route
-        path="/"
-        component={Home}
-        exact
-      />
-      <Route
-        path="/zero"
-        component={Zero}
-        exact
-      />
-      <Route
-        path="/first"
-        component={First}
-        exact
-      />
-      <Route
-        path="/second"
-        component={Second}
-        exact
-      />
-    </Switch>
-  </div>
-);
-
-export default App;
+describe('First', () => {
+  it('should render correctly', () => {
+    expect(shallowToJson(shallow(<First />))).toMatchSnapshot();
+  });
+});

--- a/src/components/MatrixCanvas.jsx
+++ b/src/components/MatrixCanvas.jsx
@@ -1,0 +1,92 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2019 char-lie
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+
+import drawMatrix from '../scripts/drawMatrix';
+
+/**
+ * @param width in pixels
+ * @param height in pixels
+ * @param palette optional object, array or function with color palette:
+ *   - default is the identity function to use a matrix with colors;
+ *   - you can provide an object or array to map color identifiers to colors;
+ *   - you can also provide the mapping via a function.
+ * @param matrix with colors
+ *   - strings with RGB colors in CSS format with hash
+ *   - numbers with indices of colors from the palette
+ */
+class MatrixCanvas extends Component {
+  componentDidUpdate() {
+    const {
+      matrix,
+      height,
+      palette,
+      width,
+    } = this.props;
+    const context = this.canvas.getContext('2d');
+    const scaleX = width / matrix[0].length;
+    const scaleY = height / matrix.length;
+    drawMatrix({
+      context,
+      matrix,
+      palette,
+      scaleX,
+      scaleY,
+    });
+  }
+
+  render() {
+    const { height, width } = this.props;
+    return (
+      <div>
+        <canvas
+          ref={(component) => { this.canvas = component; }}
+          width={width}
+          height={height}
+        />
+      </div>
+    );
+  }
+}
+
+MatrixCanvas.propTypes = {
+  height: PropTypes.number.isRequired,
+  matrix: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.oneOfType([
+    PropTypes.number,
+    PropTypes.string,
+  ]))).isRequired,
+  width: PropTypes.number.isRequired,
+  palette: PropTypes.oneOfType([
+    PropTypes.objectOf(PropTypes.string),
+    PropTypes.arrayOf(PropTypes.string),
+    PropTypes.func,
+  ]),
+};
+
+MatrixCanvas.defaultProps = {
+  palette: (color) => color,
+};
+
+export default MatrixCanvas;

--- a/src/components/MatrixCanvas.test.jsx
+++ b/src/components/MatrixCanvas.test.jsx
@@ -22,48 +22,20 @@
  * SOFTWARE.
  */
 import React from 'react';
-import {
-  Link,
-  Route,
-  Switch,
-} from 'react-router-dom';
+import { mount } from 'enzyme';
+import { shallowToJson } from 'enzyme-to-json';
 
-import Zero from './Zero';
-import First from './First';
-import Second from './Second';
-import Home from './Home';
+import MatrixCanvas from './MatrixCanvas';
 
-const App = () => (
-  <div>
-    <nav>
-      <Link to="/">Home</Link>
-      <Link to="/zero">Zero</Link>
-      <Link to="/first">First</Link>
-      <Link to="/second">Second</Link>
-    </nav>
-    <Switch>
-      <Route
-        path="/"
-        component={Home}
-        exact
-      />
-      <Route
-        path="/zero"
-        component={Zero}
-        exact
-      />
-      <Route
-        path="/first"
-        component={First}
-        exact
-      />
-      <Route
-        path="/second"
-        component={Second}
-        exact
-      />
-    </Switch>
-  </div>
-);
-
-export default App;
+describe('MatrixCanvas', () => {
+  it('should render correctly', () => {
+    const wrapper = mount(
+      <MatrixCanvas
+        width={10}
+        height={20}
+        matrix={[[0, 1, 2], [3, 4, 5]]}
+      />,
+    );
+    expect(shallowToJson(wrapper)).toMatchSnapshot();
+  });
+});

--- a/src/components/Second.jsx
+++ b/src/components/Second.jsx
@@ -1,0 +1,372 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2019 char-lie
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+import React, { Component } from 'react';
+
+import MatrixCanvas from './MatrixCanvas';
+import AnimationCanvas from './AnimationCanvas';
+import HelicopterSprite from '../scripts/HelicopterSprite';
+import AidSprite from '../scripts/AidSprite';
+import AimSprite from '../scripts/AimSprite';
+
+/**
+ * The component consists of the three main parts:
+ * - Header
+ * - Control panel
+ * - Map
+ * - Heatmap
+ *
+ * The header contains only text.
+ *
+ * The control panel contains controls
+ * width and height of the map and heatmap canvas,
+ * At the moment, it also sets number of the heatmap bars
+ * and maximal distance between aid and aim.
+ *
+ * Map displays helicopters providing aid to the aim.
+ * Aim position is chosen randomly based on the heatmap.
+ * Aid drop position is chosen randomly at the moment,
+ * but then it should be chosen by the algorithm,
+ * given the heatmap (without knowing actual aim position).
+ *
+ * Heatmap is generated randomly without normalization
+ * and rendered as a sequence of grayscale rectangles.
+ */
+class Second extends Component {
+  /**
+   * Default canvas width.
+   */
+  static WIDTH = 100;
+
+  /**
+   * Height of a sky with helicopters there.
+   */
+  static SKY_HEIGHT = 100;
+
+  /**
+   * Palette for heatmap.
+   * Converts color value from `[0; 255]`
+   * to `[#000000; #FFFFFF]` grayscale.
+   */
+  static grayPalette = (color) => (
+    `#${color.toString(16).toUpperCase().padStart(2, '0').repeat(3)}`
+  );
+
+  /**
+   * Default heatmap height.
+   */
+  static HEATMAP_HEIGHT = 20;
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      aids: [],
+      aimDelta: -1,
+      aims: [],
+      barsNumber: 1,
+      heatmap: [0],
+      height: Second.SKY_HEIGHT,
+      helicopters: [],
+      width: Second.WIDTH,
+    };
+  }
+
+  /**
+   * Change the maximal good distance between aim and aid
+   * in heatmap bars.
+   * Zero beans only current bar.
+   * Set `-1` to remove the constraint.
+   */
+  changeAimDelta(inputAimDelta) {
+    let aimDelta = Number(inputAimDelta);
+    if (aimDelta < -1) {
+      aimDelta = -1;
+    }
+    aimDelta = Math.round(aimDelta);
+    this.setState((previousState) => ({
+      ...previousState,
+      aids: [],
+      aims: [],
+      aimDelta,
+      helicopters: [],
+    }));
+  }
+
+  /**
+   * Change number of bars in heatmap.
+   */
+  changeBarsNumber(inputBarsNumber) {
+    let barsNumber = Number(inputBarsNumber);
+    if (barsNumber < 1) {
+      barsNumber = 1;
+    }
+    barsNumber = Math.round(barsNumber);
+    this.setState((previousState) => ({
+      ...previousState,
+      aids: [],
+      aims: [],
+      barsNumber,
+      helicopters: [],
+    }));
+  }
+
+  /**
+   * Change number of bars in heatmap.
+   */
+  changeHeight(inputHeight) {
+    let height = Number(inputHeight);
+    if (height < 1) {
+      height = 1;
+    }
+    height = Math.round(height);
+    this.setState((previousState) => ({
+      ...previousState,
+      aids: [],
+      aims: [],
+      helicopters: [],
+      height,
+    }));
+  }
+
+  /**
+   * Change number of bars in heatmap.
+   */
+  changeWidth(inputWidth) {
+    let width = Number(inputWidth);
+    if (width < 1) {
+      width = 1;
+    }
+    width = Math.round(width);
+    this.setState((previousState) => ({
+      ...previousState,
+      aids: [],
+      aims: [],
+      helicopters: [],
+      width,
+    }));
+  }
+
+  updateSprites(time) {
+    const { aids, aims, helicopters } = this.state;
+    const existingAids = aids.filter(
+      (sprite) => !sprite.needDestroy(time),
+    );
+    aims.filter((aim) => aim.needDestroy(time) || aim.isDead(time)).forEach(
+      (aim) => aim.takeAid(),
+    );
+    const existingAims = aims.filter(
+      (sprite) => !sprite.needDestroy(time),
+    );
+    const existingHelicopters = helicopters.filter(
+      (sprite) => !sprite.needDestroy(time),
+    );
+    const stateChanges = {};
+    let change = false;
+    if (existingHelicopters.length !== helicopters.length) {
+      stateChanges.helicopters = existingHelicopters;
+      change = true;
+    }
+    if (existingAids.length !== aids.length) {
+      stateChanges.aids = existingAids;
+      change = true;
+    }
+    if (existingAims.length !== aims.length) {
+      stateChanges.aims = existingAims;
+      change = true;
+    }
+    if (change) {
+      this.setState((previousState) => ({
+        ...previousState,
+        ...stateChanges,
+      }));
+    }
+  }
+
+  generateX() {
+    const { heatmap, barsNumber, width } = this.state;
+    const cumulative = heatmap.reduce(
+      (result, value, i) => (
+        result.length
+          ? [...result, result[i - 1] + value]
+          : [value]
+      ),
+      [],
+    );
+    const value = Math.random() * cumulative[cumulative.length - 1];
+    const index = cumulative.findIndex((element) => element >= value);
+    return (width / barsNumber) * (index + 0.5);
+  }
+
+  /**
+   * Create new helicopter to drop an item.
+   */
+  drop() {
+    const {
+      aimDelta,
+      barsNumber,
+      height,
+      width,
+    } = this.state;
+
+    const helicopter = new HelicopterSprite({
+      birthDate: new Date(),
+      canvasWidth: Math.round(width),
+      canvasHeight: height,
+      offsetY: Math.random() * (height - HelicopterSprite.IMAGES[0].length * 5),
+      scale: 5,
+      velocity: 200,
+    });
+    const aid = new AidSprite({
+      birthDate: new Date(),
+      canvasHeight: height,
+      canvasWidth: Math.round(width),
+      dropX: Math.random() * (width - AidSprite.IMAGE[0].length),
+      helicopter,
+      scale: 5,
+      velocity: 200,
+    });
+    const aim = new AimSprite({
+      aid,
+      birthDate: new Date(),
+      canvasHeight: height,
+      canvasWidth: Math.round(width),
+      maxDistance: ((aimDelta + 0.5) * width) / barsNumber,
+      offsetX: this.generateX(),
+      scale: 3,
+      velocity: 100,
+    });
+    this.setState((previousState) => ({
+      ...previousState,
+      helicopters: [...previousState.helicopters, helicopter],
+      aids: [...previousState.aids, aid],
+      aims: [...previousState.aims, aim],
+    }));
+  }
+
+  /**
+   * Generate new heatmap.
+   */
+  generateHeatmap() {
+    const { barsNumber } = this.state;
+    const heatmap = [Math.random() * 255];
+    for (let i = 1; i < barsNumber; i += 1) {
+      const value = (
+        heatmap[i - 1] + ((Math.random() - 0.5) * 500) / (barsNumber ** 0.5)
+      );
+      if (value < 0) {
+        heatmap.push(0);
+      } else if (value > 255) {
+        heatmap.push(255);
+      } else {
+        heatmap.push(value);
+      }
+    }
+    this.setState((previousState) => ({
+      ...previousState,
+      aids: [],
+      aims: [],
+      heatmap: heatmap.map(Math.round),
+      helicopters: [],
+    }));
+  }
+
+  render() {
+    const {
+      aids,
+      aimDelta,
+      aims,
+      barsNumber,
+      heatmap,
+      height,
+      helicopters,
+      width,
+    } = this.state;
+    return (
+      <div>
+        <h3>Task B</h3>
+        <form>
+          <label htmlFor={this.widthInput}>
+            Width:
+            <input
+              ref={(component) => { this.widthInput = component; }}
+              type="number"
+              value={width}
+              step={1}
+              onChange={(event) => this.changeWidth(event.target.value)}
+            />
+          </label>
+          <label htmlFor={this.heightInput}>
+            Height:
+            <input
+              ref={(component) => { this.heightInput = component; }}
+              type="number"
+              value={height}
+              step={1}
+              onChange={(event) => this.changeHeight(event.target.value)}
+            />
+          </label>
+          <label htmlFor={this.barsNumberInput}>
+            Bars number:
+            <input
+              ref={(component) => { this.barsNumberInput = component; }}
+              type="number"
+              value={barsNumber}
+              step={1}
+              onChange={(event) => this.changeBarsNumber(event.target.value)}
+            />
+          </label>
+          <label htmlFor={this.aimDeltaInput}>
+            Aim life delta:
+            <input
+              ref={(component) => { this.aimDeltaInput = component; }}
+              type="number"
+              value={aimDelta}
+              step={1}
+              onChange={(event) => this.changeAimDelta(event.target.value)}
+            />
+          </label>
+          <button type="button" onClick={() => this.generateHeatmap()}>
+            Next
+          </button>
+          <button type="button" onClick={() => this.drop()}>
+            Drop
+          </button>
+        </form>
+        <AnimationCanvas
+          height={height}
+          width={Math.round(width)}
+          sprites={[...helicopters, ...aids, ...aims]}
+          updateSprites={(time) => this.updateSprites(time)}
+        />
+        <MatrixCanvas
+          height={Math.round(Second.HEATMAP_HEIGHT)}
+          width={width}
+          matrix={[heatmap]}
+          palette={Second.grayPalette}
+        />
+      </div>
+    );
+  }
+}
+
+export default Second;

--- a/src/components/Second.test.jsx
+++ b/src/components/Second.test.jsx
@@ -22,48 +22,13 @@
  * SOFTWARE.
  */
 import React from 'react';
-import {
-  Link,
-  Route,
-  Switch,
-} from 'react-router-dom';
+import { shallow } from 'enzyme';
+import { shallowToJson } from 'enzyme-to-json';
 
-import Zero from './Zero';
-import First from './First';
 import Second from './Second';
-import Home from './Home';
 
-const App = () => (
-  <div>
-    <nav>
-      <Link to="/">Home</Link>
-      <Link to="/zero">Zero</Link>
-      <Link to="/first">First</Link>
-      <Link to="/second">Second</Link>
-    </nav>
-    <Switch>
-      <Route
-        path="/"
-        component={Home}
-        exact
-      />
-      <Route
-        path="/zero"
-        component={Zero}
-        exact
-      />
-      <Route
-        path="/first"
-        component={First}
-        exact
-      />
-      <Route
-        path="/second"
-        component={Second}
-        exact
-      />
-    </Switch>
-  </div>
-);
-
-export default App;
+describe('Second', () => {
+  it('should render correctly', () => {
+    expect(shallowToJson(shallow(<Second />))).toMatchSnapshot();
+  });
+});

--- a/src/components/Zero.jsx
+++ b/src/components/Zero.jsx
@@ -1,0 +1,144 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2019 char-lie
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+import React, { Component } from 'react';
+
+/**
+ * The component consists of three main parts:
+ * - Header
+ * - Session name input panel
+ * - Messages list
+ *
+ * The header contains the practicum name.
+ *
+ * The session name input panel contains one text input and a button.
+ * You enter existing session identifier and click the button
+ * to create WebSocket client.
+ *
+ * Messages list will be populated by messages
+ * received by the client as an observer.
+ */
+class Zero extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      messages: [],
+      sessionId: '',
+      ws: null,
+    };
+  }
+
+  observeSession() {
+    const {
+      ws: oldWS,
+    } = this.state;
+    const sessionId = this.sessionId.value;
+    if (oldWS && [oldWS.CONNECTING, oldWS.OPEN].includes(oldWS.readyState)) {
+      oldWS.removeEventListener('open', oldWS.onopen);
+      oldWS.removeEventListener('close', oldWS.onclose);
+      oldWS.removeEventListener('error', oldWS.onerror);
+      oldWS.close(1000);
+    }
+    const HOST = window.location.origin.replace(/^http/, 'ws');
+    const ws = new WebSocket(`${HOST}/zero/${sessionId}`);
+    ws.addEventListener('open', () => {
+      const message = {
+        author: 'Client',
+        data: `Connect to session ${sessionId}`,
+      };
+      this.setState((previousState) => ({
+        ...previousState,
+        messages: [...previousState.messages, message],
+      }));
+    });
+    ws.addEventListener('close', ({ code, target: { url } }) => {
+      const message = {
+        author: 'Client',
+        data: `Disconnected from ${url} with code ${code}`,
+      };
+      this.setState((previousState) => ({
+        ...previousState,
+        messages: [...previousState.messages, message],
+      }));
+    });
+    ws.addEventListener('error', ({ target: { url } }) => {
+      const message = {
+        author: 'Client',
+        data: `Error in ${url}`,
+      };
+      this.setState((previousState) => ({
+        ...previousState,
+        messages: [...previousState.messages, message],
+      }));
+    });
+    ws.addEventListener('message', ({ data: message }) => {
+      const colonIndex = message.search(':');
+      const author = colonIndex === -1 ? '' : message.slice(0, colonIndex);
+      const dataIndex = colonIndex === -1 ? 0 : colonIndex + 2;
+      const data = message.slice(dataIndex, message.length);
+      const newMessage = { author, data };
+      this.setState((previousState) => ({
+        ...previousState,
+        messages: [...previousState.messages, newMessage],
+      }));
+    });
+    this.setState((previousState) => ({
+      ...previousState,
+      messages: [],
+      sessionId,
+      ws,
+    }));
+  }
+
+  render() {
+    const {
+      messages,
+      sessionId,
+    } = this.state;
+    const messagesHtml = messages.map((message) => (
+      <li>
+        {message.author}
+        {': '}
+        {message.data}
+      </li>
+    ));
+    return (
+      <div>
+        <h3>Task 0</h3>
+        <label htmlFor={this.sessionId}>
+        Session ID:
+          <input
+            ref={(component) => { this.sessionId = component; }}
+          />
+        </label>
+        <button type="button" onClick={() => this.observeSession()}>
+        Observe
+        </button>
+        <div>{sessionId}</div>
+        <ul>{messagesHtml}</ul>
+      </div>
+    );
+  }
+}
+
+export default Zero;

--- a/src/components/Zero.test.jsx
+++ b/src/components/Zero.test.jsx
@@ -22,48 +22,13 @@
  * SOFTWARE.
  */
 import React from 'react';
-import {
-  Link,
-  Route,
-  Switch,
-} from 'react-router-dom';
+import { shallow } from 'enzyme';
+import { shallowToJson } from 'enzyme-to-json';
 
 import Zero from './Zero';
-import First from './First';
-import Second from './Second';
-import Home from './Home';
 
-const App = () => (
-  <div>
-    <nav>
-      <Link to="/">Home</Link>
-      <Link to="/zero">Zero</Link>
-      <Link to="/first">First</Link>
-      <Link to="/second">Second</Link>
-    </nav>
-    <Switch>
-      <Route
-        path="/"
-        component={Home}
-        exact
-      />
-      <Route
-        path="/zero"
-        component={Zero}
-        exact
-      />
-      <Route
-        path="/first"
-        component={First}
-        exact
-      />
-      <Route
-        path="/second"
-        component={Second}
-        exact
-      />
-    </Switch>
-  </div>
-);
-
-export default App;
+describe('Zero', () => {
+  it('should render correctly', () => {
+    expect(shallowToJson(shallow(<Zero />))).toMatchSnapshot();
+  });
+});

--- a/src/components/__snapshots__/App.test.jsx.snap
+++ b/src/components/__snapshots__/App.test.jsx.snap
@@ -18,6 +18,11 @@ exports[`App should render correctly 1`] = `
     >
       First
     </Link>
+    <Link
+      to="/second"
+    >
+      Second
+    </Link>
   </nav>
   <Switch>
     <Route
@@ -34,6 +39,11 @@ exports[`App should render correctly 1`] = `
       component={[Function]}
       exact={true}
       path="/first"
+    />
+    <Route
+      component={[Function]}
+      exact={true}
+      path="/second"
     />
   </Switch>
 </div>

--- a/src/components/__snapshots__/First.test.jsx.snap
+++ b/src/components/__snapshots__/First.test.jsx.snap
@@ -1,0 +1,61 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`First should render correctly 1`] = `
+<div>
+  <h3>
+    Task A
+  </h3>
+  <form>
+    <label>
+      Width:
+      <input
+        onChange={[Function]}
+        step={1}
+        type="number"
+        value={1}
+      />
+    </label>
+    <label>
+      Height:
+      <input
+        onChange={[Function]}
+        step={1}
+        type="number"
+        value={1}
+      />
+    </label>
+    <label>
+      Noise level:
+      <input
+        onChange={[Function]}
+        step={0.1}
+        type="number"
+        value={0}
+      />
+    </label>
+    <button
+      onClick={[Function]}
+      type="button"
+    >
+      Next
+    </button>
+  </form>
+  <MatrixCanvas
+    height={500}
+    matrix={
+      Array [
+        Array [
+          0,
+        ],
+      ]
+    }
+    palette={
+      Object {
+        "0": "#FFFFFF",
+        "1": "#000000",
+      }
+    }
+    width={300}
+  />
+</div>
+`;

--- a/src/components/__snapshots__/MatrixCanvas.test.jsx.snap
+++ b/src/components/__snapshots__/MatrixCanvas.test.jsx.snap
@@ -1,0 +1,30 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`MatrixCanvas should render correctly 1`] = `
+<MatrixCanvas
+  height={20}
+  matrix={
+    Array [
+      Array [
+        0,
+        1,
+        2,
+      ],
+      Array [
+        3,
+        4,
+        5,
+      ],
+    ]
+  }
+  palette={[Function]}
+  width={10}
+>
+  <div>
+    <canvas
+      height={20}
+      width={10}
+    />
+  </div>
+</MatrixCanvas>
+`;

--- a/src/components/__snapshots__/Second.test.jsx.snap
+++ b/src/components/__snapshots__/Second.test.jsx.snap
@@ -1,0 +1,77 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Second should render correctly 1`] = `
+<div>
+  <h3>
+    Task B
+  </h3>
+  <form>
+    <label>
+      Width:
+      <input
+        onChange={[Function]}
+        step={1}
+        type="number"
+        value={100}
+      />
+    </label>
+    <label>
+      Height:
+      <input
+        onChange={[Function]}
+        step={1}
+        type="number"
+        value={100}
+      />
+    </label>
+    <label>
+      Bars number:
+      <input
+        onChange={[Function]}
+        step={1}
+        type="number"
+        value={1}
+      />
+    </label>
+    <label>
+      Aim life delta:
+      <input
+        onChange={[Function]}
+        step={1}
+        type="number"
+        value={-1}
+      />
+    </label>
+    <button
+      onClick={[Function]}
+      type="button"
+    >
+      Next
+    </button>
+    <button
+      onClick={[Function]}
+      type="button"
+    >
+      Drop
+    </button>
+  </form>
+  <AnimationCanvas
+    height={100}
+    sprites={Array []}
+    updateSprites={[Function]}
+    width={100}
+  />
+  <MatrixCanvas
+    height={20}
+    matrix={
+      Array [
+        Array [
+          0,
+        ],
+      ]
+    }
+    palette={[Function]}
+    width={100}
+  />
+</div>
+`;

--- a/src/components/__snapshots__/Zero.test.jsx.snap
+++ b/src/components/__snapshots__/Zero.test.jsx.snap
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Zero should render correctly 1`] = `
+<div>
+  <h3>
+    Task 0
+  </h3>
+  <label>
+    Session ID:
+    <input />
+  </label>
+  <button
+    onClick={[Function]}
+    type="button"
+  >
+    Observe
+  </button>
+  <div />
+  <ul />
+</div>
+`;


### PR DESCRIPTION
- Split the `First` task into `First` and `Second`
  and move all tasks to the `src/components`
  from their subfolders.
- Add testing of the second task routing.
- Fix snapshots.
- Update CHANGELOG.
- Update `npm` version.