### PR TITLE
Fix #49: The first task executor fails on non-unity scales

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -51,6 +51,7 @@ Fixed
   as the ``AimSprite`` starting position,
   aid should not be destroyed until the aim landing.
 - UI error when switching from the ``Second`` task to any other.
+- The first task server fail on scales greater than ``1``.
 
 0.0.1 - 2019-07-28
 ==================

--- a/src/server/WSExecutorFirst.js
+++ b/src/server/WSExecutorFirst.js
@@ -372,7 +372,7 @@ class WSExecutorFirst extends WSExecutor {
         matrix.push([]);
         for (let j = 0; j < row.length; j += 1) {
           for (let w = 0; w < this.horizontalScale; w += 1) {
-            matrix[h * WSExecutorFirst.BASIC_HEIGHT + i].push(
+            matrix[i * this.verticalScale + h].push(
               this.applyElementNoise(idealDigit[i][j]),
             );
           }


### PR DESCRIPTION
I used `h * WSExecutorFirst.BASIC_HEIGHT + i`
for the final digit matrix row index,
where `i` is the ideal digit row index
and `h` is a number of the current row repetition.
The code contains a mistake,
because I've written it like I want to index a matrix
by a 1D array, and causes the error
```
.../pattern-recognition-server/src/server/WSExecutorFirst.js:375                                                                                                                           [126/1941]
            matrix[h * WSExecutorFirst.BASIC_HEIGHT + i].push(
                                                         ^

TypeError: Cannot read property 'push' of undefined
    at .../pattern-recognition-server/src/server/WSExecutorFirst.js:375:58
    at Array.forEach (<anonymous>)
    at WSExecutorFirst.generateMatrix (.../pattern-recognition-server/src/server/WSExecutorFirst.js:370:16)
    at WSExecutorFirst.onReady (.../pattern-recognition-server/src/server/WSExecutorFirst.js:310:25)
    at WSExecutorFirst.onMessage (.../pattern-recognition-server/src/server/WSExecutorFirst.js:219:14)
    at WSExecutorFirst._onMessage (.../pattern-recognition-server/src/server/WSClientListener.js:83:10)
    at WebSocket.<anonymous> (.../pattern-recognition-server/src/server/WSClientListener.js:73:44)
    at WebSocket.emit (events.js:203:13)
    at Receiver.receiverOnMessage (.../pattern-recognition-server/node_modules/ws/lib/websocket.js:800:20)
    at Receiver.emit (events.js:203:13)
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! pattern-recognition-server@0.0.1 start: `node src/server/index.js`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the pattern-recognition-server@0.0.1 start script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
```

The correct index is `i * this.verticalScale + h`:
there are `vertical scale` rows of the final digit
from one row to its neighbor of the ideal digit.