### PR TITLE
Close #29: Use logger in webserver

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,6 +8,7 @@
   "parser": "babel-eslint",
   "rules": {
     "class-methods-use-this": "warn",
+    "no-console": "error",
     "no-underscore-dangle": ["error", {
         "allowAfterThis": true
     }]

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,7 @@ Added
 - Tasks completion instructions to ``Home`` component and README_.
 - ``Zero`` component for the test practicum (practicum zero).
 - ``WSTable`` component to view WebSocket messages.
+- winston_ logger to the server.
 
 - WebSocket_ ``server`` module.
 
@@ -105,3 +106,5 @@ Added
     https://expressjs.com
 .. _WebSocket:
     https://github.com/websockets/ws
+.. _winston:
+    https://www.npmjs.com/package/winston

--- a/README.rst
+++ b/README.rst
@@ -52,7 +52,7 @@ Environment variables
 - ``MAX_CONNECTED_CLIENTS`` is the WebSocket connection pool size.
   ``1`` by default.
 - ``LOG_LEVEL`` is the bottom line of the logs severities.
-  Uses winston_ logger syslog_ levels.
+  Uses syslog_ levels of winston_ logger.
   The default value is ``warning``.
 
 Tasks
@@ -217,4 +217,4 @@ Right answers (aim coordinates) are generated according to the heatmap.
 .. _winston:
     https://www.npmjs.com/package/winston
 .. _syslog:
-  https://www.npmjs.com/package/winston#logging-levels
+    https://www.npmjs.com/package/winston#logging-levels

--- a/README.rst
+++ b/README.rst
@@ -51,6 +51,9 @@ Environment variables
   ``3000`` by default.
 - ``MAX_CONNECTED_CLIENTS`` is the WebSocket connection pool size.
   ``1`` by default.
+- ``LOG_LEVEL`` is the bottom line of the logs severities.
+  Uses winston_ logger syslog_ levels.
+  The default value is ``warning``.
 
 Tasks
 =====
@@ -211,3 +214,7 @@ Right answers (aim coordinates) are generated according to the heatmap.
     https://nodejs.org
 .. _sprs.herokuapp.com:
     https://sprs.herokuapp.com
+.. _winston:
+    https://www.npmjs.com/package/winston
+.. _syslog:
+  https://www.npmjs.com/package/winston#logging-levels

--- a/package-lock.json
+++ b/package-lock.json
@@ -3724,11 +3724,19 @@
         "object-visit": "^1.0.0"
       }
     },
+    "color": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/color/-/color-3.0.0.tgz",
+      "integrity": "sha512-jCpd5+s0s0t7p3pHQKpnJ0TpQKKdleP71LWcA0aqiljpiuAkOSUFN/dyH8ZwF0hRmFlrIuRhufds1QyEP9EB+w==",
+      "requires": {
+        "color-convert": "^1.9.1",
+        "color-string": "^1.5.2"
+      }
+    },
     "color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
       "requires": {
         "color-name": "1.1.3"
       }
@@ -3736,14 +3744,36 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+    },
+    "color-string": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.3.tgz",
+      "integrity": "sha512-dC2C5qeWoYkxki5UAXapdjqO672AM4vZuPGRQfO8b5HKuKGBbKWpITyDYN7TOFKvRW7kOgAn3746clDBMDJyQw==",
+      "requires": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
+    },
+    "colornames": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/colornames/-/colornames-1.1.1.tgz",
+      "integrity": "sha1-+IiQMGhcfE/54qVZ9Qd+t2qBb5Y="
     },
     "colors": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
       "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
       "dev": true
+    },
+    "colorspace": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.2.tgz",
+      "integrity": "sha512-vt+OoIP2d76xLhjwbBaucYlNSpPsrJWPlBTtwCpQKIu6/CSMutyzX93O/Do0qzpH3YoHEes8YEFXyZ797rEhzQ==",
+      "requires": {
+        "color": "3.0.x",
+        "text-hex": "1.0.x"
+      }
     },
     "combined-stream": {
       "version": "1.0.8",
@@ -4012,8 +4042,7 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-      "dev": true
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "cosmiconfig": {
       "version": "5.2.1",
@@ -4540,6 +4569,16 @@
       "integrity": "sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw==",
       "dev": true
     },
+    "diagnostics": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/diagnostics/-/diagnostics-1.1.1.tgz",
+      "integrity": "sha512-8wn1PmdunLJ9Tqbx+Fx/ZEuHfJf4NKSN2ZBj7SJC/OWRWha843+WsTjqMe1B5E3p28jqBlp+mJ2fPVxPyNgYKQ==",
+      "requires": {
+        "colorspace": "1.1.x",
+        "enabled": "1.0.x",
+        "kuler": "1.0.x"
+      }
+    },
     "diff-sequences": {
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-24.9.0.tgz",
@@ -4797,6 +4836,14 @@
       "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
       "dev": true
     },
+    "enabled": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/enabled/-/enabled-1.0.2.tgz",
+      "integrity": "sha1-ll9lE9LC0cX0ZStkouM5ZGf8L5M=",
+      "requires": {
+        "env-variable": "0.0.x"
+      }
+    },
     "encodeurl": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
@@ -4835,6 +4882,11 @@
       "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
       "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
       "dev": true
+    },
+    "env-variable": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/env-variable/-/env-variable-0.0.5.tgz",
+      "integrity": "sha512-zoB603vQReOFvTg5xMl9I1P2PnHsHQQKTEowsKKD7nseUfJq6UWzK+4YtlWUO1nhiQUxe6XMkk+JleSZD1NZFA=="
     },
     "enzyme": {
       "version": "3.10.0",
@@ -5853,6 +5905,11 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "fast-safe-stringify": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.6.tgz",
+      "integrity": "sha512-q8BZ89jjc+mz08rSxROs8VsrBBcn1SIw1kq9NjolL509tkABRk9io01RAjSaEv1Xb2uFLt8VtRiZbGp5H8iDtg=="
+    },
     "faye-websocket": {
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
@@ -5891,6 +5948,11 @@
           "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
         }
       }
+    },
+    "fecha": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fecha/-/fecha-2.3.3.tgz",
+      "integrity": "sha512-lUGBnIamTAwk4znq5BcqsDaxSmZ9nDVJaij6NvRt/Tg4R69gERA+otPKbS86ROw9nxVMw2/mp1fnaiWqbs6Sdg=="
     },
     "figgy-pudding": {
       "version": "3.5.1",
@@ -7602,8 +7664,7 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "ini": {
       "version": "1.3.5",
@@ -10497,6 +10558,14 @@
       "integrity": "sha512-P+0a/gBzLgVlCnK8I7VcD0yuYJscmWn66wH9tlKsQnmVdg689tLEmziwB9PuazZYLkcm07fvWOKCJJqI55sD5Q==",
       "dev": true
     },
+    "kuler": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/kuler/-/kuler-1.0.1.tgz",
+      "integrity": "sha512-J9nVUucG1p/skKul6DU3PUZrhs0LPulNaeUOox0IyXDi8S4CztTHs1gQphhuZmzXG7VOQSf6NJfKuzteQLv9gQ==",
+      "requires": {
+        "colornames": "^1.1.1"
+      }
+    },
     "latest-version": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-5.1.0.tgz",
@@ -10609,8 +10678,7 @@
     "lodash": {
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-      "dev": true
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "lodash._baseisequal": {
       "version": "3.0.7",
@@ -10701,6 +10769,25 @@
       "dev": true,
       "requires": {
         "chalk": "^2.4.2"
+      }
+    },
+    "logform": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/logform/-/logform-2.1.2.tgz",
+      "integrity": "sha512-+lZh4OpERDBLqjiwDLpAWNQu6KMjnlXH2ByZwCuSqVPJletw0kTWJf5CgSNAUKn1KUkv3m2cUz/LK8zyEy7wzQ==",
+      "requires": {
+        "colors": "^1.2.1",
+        "fast-safe-stringify": "^2.0.4",
+        "fecha": "^2.3.3",
+        "ms": "^2.1.1",
+        "triple-beam": "^1.3.0"
+      },
+      "dependencies": {
+        "colors": {
+          "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.3.tgz",
+          "integrity": "sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg=="
+        }
       }
     },
     "loglevel": {
@@ -11355,8 +11442,7 @@
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "multicast-dns": {
       "version": "6.2.3",
@@ -15530,6 +15616,11 @@
         "wrappy": "1"
       }
     },
+    "one-time": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/one-time/-/one-time-0.0.4.tgz",
+      "integrity": "sha1-+M33eISCb+Tf+T46nMN7HkSAdC4="
+    },
     "onetime": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
@@ -16406,8 +16497,7 @@
     "process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "dev": true
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
     "progress": {
       "version": "2.0.3",
@@ -16955,7 +17045,6 @@
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
       "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
-      "dev": true,
       "requires": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -17838,6 +17927,21 @@
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
       "dev": true
     },
+    "simple-swizzle": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
+      "requires": {
+        "is-arrayish": "^0.3.1"
+      },
+      "dependencies": {
+        "is-arrayish": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+          "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
+        }
+      }
+    },
     "sisteransi": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.3.tgz",
@@ -18234,6 +18338,11 @@
         "figgy-pudding": "^3.5.1"
       }
     },
+    "stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
+    },
     "stack-utils": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.2.tgz",
@@ -18440,7 +18549,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.2.0.tgz",
       "integrity": "sha512-6YqyX6ZWEYguAxgZzHGL7SsCeGx3V2TtOTqZz1xSTSWnqsbWwbptafNyvf/ACquZUXV3DANr5BDIwNYe1mN42w==",
-      "dev": true,
       "requires": {
         "safe-buffer": "~5.1.0"
       }
@@ -18951,6 +19059,11 @@
         }
       }
     },
+    "text-hex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
+      "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg=="
+    },
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -19164,6 +19277,11 @@
       "resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-1.1.2.tgz",
       "integrity": "sha512-MUjYItdrqqj2zpcHFTkMa9WAv4JHTI6gnRQGPFLrt5L9a6tRMiDnIqYl8JBvu2d2Tc3lWJKQwlGCp0K8AvCM+Q==",
       "dev": true
+    },
+    "triple-beam": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.3.0.tgz",
+      "integrity": "sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw=="
     },
     "trough": {
       "version": "1.0.4",
@@ -19587,8 +19705,7 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "util.promisify": {
       "version": "1.0.0",
@@ -20262,6 +20379,70 @@
           "dev": true,
           "requires": {
             "ansi-regex": "^3.0.0"
+          }
+        }
+      }
+    },
+    "winston": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.2.1.tgz",
+      "integrity": "sha512-zU6vgnS9dAWCEKg/QYigd6cgMVVNwyTzKs81XZtTFuRwJOcDdBg7AU0mXVyNbs7O5RH2zdv+BdNZUlx7mXPuOw==",
+      "requires": {
+        "async": "^2.6.1",
+        "diagnostics": "^1.1.1",
+        "is-stream": "^1.1.0",
+        "logform": "^2.1.1",
+        "one-time": "0.0.4",
+        "readable-stream": "^3.1.1",
+        "stack-trace": "0.0.x",
+        "triple-beam": "^1.3.0",
+        "winston-transport": "^4.3.0"
+      },
+      "dependencies": {
+        "async": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+          "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+          "requires": {
+            "lodash": "^4.17.14"
+          }
+        }
+      }
+    },
+    "winston-transport": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.3.0.tgz",
+      "integrity": "sha512-B2wPuwUi3vhzn/51Uukcao4dIduEiPOcOt9HJ3QeaXgkJ5Z7UwpBzxS4ZGNHtrxrUvTwemsQiSys0ihOf8Mp1A==",
+      "requires": {
+        "readable-stream": "^2.3.6",
+        "triple-beam": "^1.2.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "react-dom": "^16.9.0",
     "react-router": "^5.0.1",
     "react-router-dom": "^5.0.1",
+    "winston": "^3.2.1",
     "ws": "^7.1.2"
   }
 }

--- a/src/server/Logger.js
+++ b/src/server/Logger.js
@@ -1,0 +1,52 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2019 char-lie
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+const {
+  config: { syslog: { levels } },
+  createLogger,
+  format,
+  transports: { Console },
+} = require('winston');
+
+const DEFAULT_LOG_LEVEL = 'warning';
+const LOG_LEVEL = (process.env.LOG_LEVEL in levels
+  ? process.env.LOG_LEVEL
+  : DEFAULT_LOG_LEVEL);
+
+const Logger = (componentName = 'server') => createLogger({
+  format: format.combine(
+    format.colorize(),
+    format.timestamp({
+      format: 'YYYY-MM-DD HH:mm:ss',
+    }),
+    format.printf((info) => (
+      `${info.timestamp} [${info.level}] ${componentName}: `
+      + `${info.message}`
+    )),
+  ),
+  level: LOG_LEVEL,
+  levels,
+  transports: [new Console()],
+});
+
+module.exports = Logger;

--- a/src/server/Logger.js
+++ b/src/server/Logger.js
@@ -29,8 +29,8 @@ const {
 } = require('winston');
 
 const DEFAULT_LOG_LEVEL = 'warning';
-const LOG_LEVEL = (process.env.LOG_LEVEL in levels
-  ? process.env.LOG_LEVEL
+const LOG_LEVEL = (process.env.LOG_LEVEL.toLowerCase() in levels
+  ? process.env.LOG_LEVEL.toLowerCase()
   : DEFAULT_LOG_LEVEL);
 
 const Logger = (componentName = 'server') => createLogger({

--- a/src/server/WSClientListener.js
+++ b/src/server/WSClientListener.js
@@ -33,12 +33,14 @@ class WSClientListener {
     afterClose = () => {},
     afterMessage = () => {},
     connectionDate,
+    logger,
     socket,
     ttl = DEFAULT_WS_TTL_MILLISECONDS,
   }) {
     this.afterClose = afterClose;
     this.afterMessage = afterMessage;
     this.connectionDate = connectionDate;
+    this.logger = logger;
     this.socket = socket;
     this.ttl = ttl;
     this.ttlTimeout = setTimeout(
@@ -51,16 +53,13 @@ class WSClientListener {
     this._registerListeners(this.socket);
   }
 
-  onError(error) {
-    console.error(error);
+  onError() {
   }
 
-  onMessage(message) {
-    console.log(message);
+  onMessage() {
   }
 
   onClose() {
-    console.log('Close client');
   }
 
   close() {
@@ -76,17 +75,20 @@ class WSClientListener {
   _onError(error) {
     clearTimeout(this.ttlTimeout);
     this.onError(error);
+    this.logger.warning(`An error occurred: ${error}`);
     this.afterClose();
   }
 
   _onMessage(message) {
     this.onMessage(message);
+    this.logger.debug(`Receive message ${message}`);
     this.afterMessage(message);
   }
 
   _onClose() {
     clearTimeout(this.ttlTimeout);
     this.onClose();
+    this.logger.info('Close socket');
     this.afterClose();
   }
 }

--- a/src/server/WSExecutor.js
+++ b/src/server/WSExecutor.js
@@ -35,10 +35,6 @@ class WSExecutor extends WSClientListener {
     super(data);
     this.send = send;
   }
-
-  onMessage(message) {
-    console.log(`Executor says: '${message}'`);
-  }
 }
 
 module.exports = WSExecutor;

--- a/src/server/WSExecutorFirst.js
+++ b/src/server/WSExecutorFirst.js
@@ -21,6 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+const Logger = require('./Logger');
 const WSExecutor = require('./WSExecutor');
 
 /**
@@ -192,7 +193,10 @@ class WSExecutorFirst extends WSExecutor {
   }
 
   constructor(data) {
-    super(data);
+    super({
+      ...data,
+      logger: Logger('Task 3'),
+    });
 
     this.currentSolution = null;
     this.currentStep = 0;
@@ -203,11 +207,10 @@ class WSExecutorFirst extends WSExecutor {
     this.totalSteps = null;
     this.verticalScale = null;
 
-    console.log('Executor First created');
+    this.logger.info('Executor First created');
   }
 
   onMessage(message) {
-    console.log(`Executor says: '${message}'`);
     switch (this.state) {
       case WSExecutorFirst.STATES.START:
         this.onStart(message);
@@ -225,7 +228,8 @@ class WSExecutorFirst extends WSExecutor {
         this.onFinish(message);
         break;
       default:
-        console.error(`Unknown state ${this.state}`);
+        this.logger.alert(`Unknown state ${this.state}`);
+        this.socket.close();
         break;
     }
   }
@@ -332,7 +336,7 @@ class WSExecutorFirst extends WSExecutor {
     } else if (this.currentStep === this.totalSteps) {
       this.state = WSExecutorFirst.STATES.FINISH;
     } else {
-      console.error(`We have step ${this.currentStep} of ${this.totalSteps}!`);
+      this.logger.alert(`We have step ${this.currentStep} of ${this.totalSteps}!`);
       this.socket.close();
       return;
     }

--- a/src/server/WSExecutorSecond.js
+++ b/src/server/WSExecutorSecond.js
@@ -21,6 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+const Logger = require('./Logger');
 const WSExecutor = require('./WSExecutor');
 
 /**
@@ -117,7 +118,10 @@ class WSExecutorSecond extends WSExecutor {
   static L1_LOSS_NAME = 'L1';
 
   constructor(data) {
-    super(data);
+    super({
+      ...data,
+      logger: Logger('Task 2'),
+    });
 
     this.barsNumber = null;
     this.currentHistorgram = null;
@@ -129,11 +133,10 @@ class WSExecutorSecond extends WSExecutor {
     this.totalLoss = 0;
     this.totalSteps = null;
 
-    console.log('Executor Second created');
+    this.logger.info('Executor Second created');
   }
 
   onMessage(message) {
-    console.log(`Executor says: '${message}'`);
     switch (this.state) {
       case WSExecutorSecond.STATES.START:
         this.onStart(message);
@@ -148,7 +151,8 @@ class WSExecutorSecond extends WSExecutor {
         this.onFinish(message);
         break;
       default:
-        console.error(`Unknown state ${this.state}`);
+        this.logger.alert(`Unknown state ${this.state}`);
+        this.socket.close();
         break;
     }
   }
@@ -268,7 +272,7 @@ class WSExecutorSecond extends WSExecutor {
     } else if (this.currentStep === this.totalSteps) {
       this.state = WSExecutorSecond.STATES.FINISH;
     } else {
-      console.error(`We have step ${this.currentStep} of ${this.totalSteps}!`);
+      this.logger.alert(`We have step ${this.currentStep} of ${this.totalSteps}!`);
       this.socket.close();
       return;
     }

--- a/src/server/WSExecutorZero.js
+++ b/src/server/WSExecutorZero.js
@@ -21,6 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+const Logger = require('./Logger');
 const WSExecutor = require('./WSExecutor');
 
 /**
@@ -54,14 +55,17 @@ class WSExecutorZero extends WSExecutor {
   static DEFAULT_TTL = WSExecutorZero.DEFAULT_TTL_SECONDS * 1E3;
 
   constructor(data) {
-    super(data);
+    super({
+      ...data,
+      logger: Logger('Task 0'),
+    });
+
     this.state = WSExecutorZero.STATES.START;
     this.expression = null;
-    console.log('Zero executor created');
+    this.logger.info('Zero executor created');
   }
 
   onMessage(message) {
-    console.log(`Executor says: '${message}'`);
     switch (this.state) {
       case WSExecutorZero.STATES.START:
         this.onStart(message);
@@ -70,7 +74,8 @@ class WSExecutorZero extends WSExecutor {
         this.onSolve(message);
         break;
       default:
-        console.error(`Unknown state ${this.state}`);
+        this.logger.alert(`Unknown state ${this.state}`);
+        this.socket.close();
         break;
     }
   }

--- a/src/server/WSObserver.js
+++ b/src/server/WSObserver.js
@@ -21,6 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+const Logger = require('./Logger');
 const WSClientListener = require('./WSClientListener');
 
 /**
@@ -29,12 +30,20 @@ const WSClientListener = require('./WSClientListener');
  * Attempts to send a message end up with connection close.
  */
 class WSObserver extends WSClientListener {
+  constructor(data) {
+    super({
+      ...data,
+      logger: Logger('Observer'),
+    });
+  }
+
   onMessage(message) {
-    console.log(`Unexpected message from observer: '${message}'`);
+    this.logger.debug(`Unexpected message from observer: '${message}'`);
     this.socket.close();
   }
 
   send(message) {
+    this.logger.debug(`Send '${message}'`);
     this.socket.send(message);
   }
 }

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -23,11 +23,12 @@
  */
 const express = require('express');
 const path = require('path');
-const WSTaskServer = require('./WSTaskServer');
+const Logger = require('./Logger');
 const WebSocketPool = require('./WebSocketPool');
-const WSExecutorZero = require('./WSExecutorZero');
 const WSExecutorFirst = require('./WSExecutorFirst');
 const WSExecutorSecond = require('./WSExecutorSecond');
+const WSExecutorZero = require('./WSExecutorZero');
+const WSTaskServer = require('./WSTaskServer');
 
 const PORT = process.env.PORT || 3000;
 const MAX_CONNECTED_CLIENTS = Number(process.env.MAX_CONNECTED_CLIENTS) || 1;
@@ -35,11 +36,13 @@ const MAX_CONNECTED_CLIENTS = Number(process.env.MAX_CONNECTED_CLIENTS) || 1;
 const STATIC_PATH = path.join(__dirname, '..', '..', 'dist');
 const INDEX_FILE = path.join(STATIC_PATH, 'index.html');
 
+const logger = Logger();
+
 const server = express()
   .use(express.static(STATIC_PATH))
   .use((req, res) => res.sendFile(INDEX_FILE))
   .listen(PORT, () => {
-    console.log(`Pattern recognition server is listening on port ${PORT}`);
+    logger.notice(`Pattern recognition server is listening on port ${PORT}`);
   });
 
 const socketPool = new WebSocketPool(MAX_CONNECTED_CLIENTS);


### PR DESCRIPTION
- Add Winston logger dependency
- Implement custom logger on the base of Winston
- Use logger in the base WS client listener
- Using logger in `Observer`
- Remove redundant console logging of the message in the basic `Executor`
- Add loggers to concrete task executors
- Close socket after executor's alert
- Add logging to WS task server
- Add a logger to the main webserver
- Add log level management information to README
- Make linter fail on `console` statements
  https://eslint.org/docs/rules/no-console

The `Logger` is like a factory method.
It's not a class, but it's a function,
creating a new logger for a specific component,
which name is specified as the input parameter.

Inspired by
https://www.npmjs.com/package/winston
Using `syslog` verbosity levels
https://tools.ietf.org/html/rfc5424
Very helpful to make colors and timestamps
https://thisdavej.com/using-winston-a-versatile-logging-library-for-node-js/