### PR TITLE
Fix #61: Wrong order of messages

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -54,6 +54,7 @@ Fixed
   aid should not be destroyed until the aim landing.
 - UI error when switching from the ``Second`` task to any other.
 - The first task server fail on scales greater than ``1``.
+- Order of messages broadcasted by ``WSTaskServer``.
 
 0.0.1 - 2019-07-28
 ==================

--- a/package-lock.json
+++ b/package-lock.json
@@ -11792,9 +11792,9 @@
       }
     },
     "npm": {
-      "version": "6.11.2",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-6.11.2.tgz",
-      "integrity": "sha512-OAkXqI4bm5MUvqVvqe6rxCXmJqrln8VDlkdftpOoayHKazz8IOCJAiCuKmz0TchL224EAKeG86umuD6RYNpuEg==",
+      "version": "6.11.3",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-6.11.3.tgz",
+      "integrity": "sha512-K2h+MPzZiY39Xf6eHEdECe/LKoJXam4UCflz5kIxoskN3LQFeYs5fqBGT5i4TtM/aBk+86Mcf+jgXs/WuWAutQ==",
       "dev": true,
       "requires": {
         "JSONStream": "^1.3.5",
@@ -11874,7 +11874,7 @@
         "npm-lifecycle": "^3.1.3",
         "npm-package-arg": "^6.1.1",
         "npm-packlist": "^1.4.4",
-        "npm-pick-manifest": "^3.0.0",
+        "npm-pick-manifest": "^3.0.2",
         "npm-profile": "^4.0.2",
         "npm-registry-fetch": "^4.0.0",
         "npm-user-validate": "~1.0.0",
@@ -11889,7 +11889,7 @@
         "query-string": "^6.8.2",
         "qw": "~1.0.1",
         "read": "~1.0.7",
-        "read-cmd-shim": "^1.0.3",
+        "read-cmd-shim": "^1.0.4",
         "read-installed": "~4.0.3",
         "read-package-json": "^2.1.0",
         "read-package-tree": "^5.3.1",
@@ -13978,7 +13978,7 @@
           }
         },
         "npm-pick-manifest": {
-          "version": "3.0.0",
+          "version": "3.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -14412,7 +14412,7 @@
           }
         },
         "read-cmd-shim": {
-          "version": "1.0.3",
+          "version": "1.0.4",
           "bundled": true,
           "dev": true,
           "requires": {

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "jest-canvas-mock": "^2.1.1",
     "jest-enzyme": "^7.1.0",
     "mini-css-extract-plugin": "^0.8.0",
-    "npm": "^6.11.2",
+    "npm": "^6.11.3",
     "npm-check-updates": "^3.1.21",
     "postcss-loader": "^3.0.0",
     "style-loader": "^1.0.0",

--- a/src/server/WSClientListener.js
+++ b/src/server/WSClientListener.js
@@ -73,9 +73,9 @@ class WSClientListener {
   }
 
   _onError(error) {
+    this.logger.warning(`An error occurred: ${error}`);
     clearTimeout(this.ttlTimeout);
     this.onError(error);
-    this.logger.warning(`An error occurred: ${error}`);
     this.afterClose();
   }
 

--- a/src/server/WSClientListener.js
+++ b/src/server/WSClientListener.js
@@ -31,14 +31,14 @@ const DEFAULT_WS_TTL_MILLISECONDS = 30 * 1E3;
 class WSClientListener {
   constructor({
     afterClose = () => {},
-    afterMessage = () => {},
+    beforeMessage = () => {},
     connectionDate,
     logger,
     socket,
     ttl = DEFAULT_WS_TTL_MILLISECONDS,
   }) {
     this.afterClose = afterClose;
-    this.afterMessage = afterMessage;
+    this.beforeMessage = beforeMessage;
     this.connectionDate = connectionDate;
     this.logger = logger;
     this.socket = socket;
@@ -80,9 +80,9 @@ class WSClientListener {
   }
 
   _onMessage(message) {
-    this.onMessage(message);
     this.logger.debug(`Receive message ${message}`);
-    this.afterMessage(message);
+    this.beforeMessage(message);
+    this.onMessage(message);
   }
 
   _onClose() {

--- a/src/server/WSTaskServer.js
+++ b/src/server/WSTaskServer.js
@@ -181,7 +181,7 @@ class WSTaskServer {
     } else {
       const executor = new Executor({
         ...clientData,
-        afterMessage: (message) => {
+        beforeMessage: (message) => {
           this.broadcastObservers(sessionId, `Executor: ${message}`);
         },
         afterClose: () => {


### PR DESCRIPTION
- Use `beforeMessage` instead of `afterMessage` to broadcast the message to observers
- Log an error before the reaction on it
- Update `npm` package patch version