### PR TITLE
Fix #71: Loss in the second task is calculated wrong

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,13 @@ and this project adheres to `Semantic Versioning`_.
 Unreleased_
 ===========
 
+Fixed
+-----
+
+- In the second task with the ``interval`` loss function,
+  the server should send the number of failed attempts
+  instead of successful ones.
+
 `0.1.0`_ - 2019-09-19
 =====================
 

--- a/src/server/WSExecutorSecond.js
+++ b/src/server/WSExecutorSecond.js
@@ -40,7 +40,7 @@ class WSExecutorSecond extends WSExecutor {
       return (guess, answer) => Math.abs(guess - answer);
     }
     if (Number.isSafeInteger(Number(identifier))) {
-      return (guess, answer) => Math.abs(guess - answer) <= Number(identifier);
+      return (guess, answer) => Math.abs(guess - answer) > Number(identifier);
     }
     throw new Error(`Unknown loss function identifier ${identifier}`);
   }


### PR DESCRIPTION
In the second task with the ``interval`` loss function,
the server should send the number of failed attempts
instead of successful ones.
The comparison type was wrong.