### PR TITLE
Close #81: Don't allow zero steps and sizes in tasks

### DIFF
--- a/src/server/WSExecutorFirst.js
+++ b/src/server/WSExecutorFirst.js
@@ -252,7 +252,7 @@ class WSExecutorFirst extends WSExecutor {
       return;
     }
     if (
-      Math.round(this.horizontalScale) !== this.horizontalScale
+      !Number.isSafeInteger(this.horizontalScale)
       || this.horizontalScale > WSExecutorFirst.MAX_HORIZONTAL_SCALE
     ) {
       this.send('Wrong width');
@@ -260,7 +260,7 @@ class WSExecutorFirst extends WSExecutor {
       return;
     }
     if (
-      Math.round(this.verticalScale) !== this.verticalScale
+      !Number.isSafeInteger(this.verticalScale)
       || this.verticalScale > WSExecutorFirst.MAX_VERTICAL_SCALE
     ) {
       this.send('Wrong height');
@@ -268,7 +268,8 @@ class WSExecutorFirst extends WSExecutor {
       return;
     }
     if (
-      Math.round(this.totalSteps) !== this.totalSteps
+      !Number.isSafeInteger(this.totalSteps)
+      || this.totalSteps < 1
       || this.totalSteps > WSExecutorFirst.MAX_HORIZONTAL_SCALE
     ) {
       this.send('Wrong number of steps');

--- a/src/server/WSExecutorSecond.js
+++ b/src/server/WSExecutorSecond.js
@@ -119,6 +119,7 @@ class WSExecutorSecond extends WSExecutor {
 
     if (
       !Number.isSafeInteger(Number(barsNumber))
+      || Number(barsNumber) < 1
       || Number(barsNumber) > WSExecutorSecond.MAX_BARS_NUMBER
     ) {
       this.send('Incorrect number of bars');
@@ -148,6 +149,7 @@ class WSExecutorSecond extends WSExecutor {
 
     if (
       !Number.isSafeInteger(Number(totalSteps))
+      || Number(totalSteps) < 1
       || Number(totalSteps) > WSExecutorSecond.MAX_TOTAL_STEPS
     ) {
       this.send('Incorrect total steps');
@@ -158,6 +160,7 @@ class WSExecutorSecond extends WSExecutor {
 
     if (
       !Number.isSafeInteger(Number(repeats))
+      || Number(repeats) < 1
       || Number(repeats) > WSExecutorSecond.MAX_REPEATS
     ) {
       this.send('Incorrect repeats number');


### PR DESCRIPTION
It was possible to set
`repeats`, `totalSteps`, `width` and/or `height` to `0`.
Add more checks to validate and fail fast on these cases.

Use `Number.isSafeInteger(Number(x))` instead of `Math.round(x) !== x`
to check whether we have an integer,
not a `NaN`, floating point number, etc.