### PR TITLE
Fix #80: Wrong totalSteps max value

### DIFF
--- a/src/server/WSExecutorFirst.js
+++ b/src/server/WSExecutorFirst.js
@@ -270,7 +270,7 @@ class WSExecutorFirst extends WSExecutor {
     if (
       !Number.isSafeInteger(this.totalSteps)
       || this.totalSteps < 1
-      || this.totalSteps > WSExecutorFirst.MAX_HORIZONTAL_SCALE
+      || this.totalSteps > WSExecutorFirst.MAX_TOTAL_STEPS
     ) {
       this.send('Wrong number of steps');
       this.socket.close();


### PR DESCRIPTION
Compare `totalSteps` parameter
with `MAX_TOTAL_STEPS`, not with `MAX_HORIZONTAL_SCALE`.