### PR TITLE
Fix #74: Maximal payload is too small to handle the second task

### DIFF
--- a/src/server/WSTaskServer.js
+++ b/src/server/WSTaskServer.js
@@ -25,7 +25,7 @@ const WebSocket = require('ws');
 const Logger = require('./Logger');
 const WSObserver = require('./WSObserver');
 
-const MAX_PAYLOAD_KB = 1;
+const MAX_PAYLOAD_KB = 5;
 const MAX_PAYLOAD = Math.round(MAX_PAYLOAD_KB * (2 ** 10));
 
 /**


### PR DESCRIPTION
Increase the maximal payload to 5KB.
Works with `1'000` repeats and `1'000` width (number of digits matters).