### PR TITLE
Fix #73: Server fails if the only one session initialization fails

### DIFF
--- a/src/server/WSTaskServer.js
+++ b/src/server/WSTaskServer.js
@@ -217,6 +217,13 @@ class WSTaskServer {
   }
 
   closeSession(sessionId) {
+    if (!this.sessions.has(sessionId)) {
+      this.logger.warning(
+        `Unable to close the session '${sessionId}' `
+        + 'because it\'s not opened',
+      );
+      return;
+    }
     this.sessions.get(sessionId).forEach((client) => {
       client.close();
       this.socketPool.remove(client.socket);


### PR DESCRIPTION
Check whether the session we want to close
was added to sessions set.
This allows avoiding the application fail
when the session initialization fails.