### PR TITLE
Close #96: Add support for JSON format for messages

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,11 @@ and this project adheres to `Semantic Versioning`_.
 Unreleased_
 ===========
 
+Added
+-----
+
+- Server-side support of JSON messages.
+
 `0.1.1`_ - 2020-08-23
 =====================
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pattern-recognition-server",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2534,12 +2534,11 @@
       }
     },
     "ajv": {
-      "version": "6.10.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
-      "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
-      "dev": true,
+      "version": "6.12.4",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.4.tgz",
+      "integrity": "sha512-eienB2c9qVQs2KWexhkrdMLVDoIQCz5KSeLxwg9Lzk4DOfBtIK9PQwwufcsn1jjGuf9WZmqPMbGxOzfcuphJCQ==",
       "requires": {
-        "fast-deep-equal": "^2.0.1",
+        "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
@@ -6532,10 +6531,9 @@
       "dev": true
     },
     "fast-deep-equal": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
-      "dev": true
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "fast-glob": {
       "version": "3.2.4",
@@ -6554,8 +6552,7 @@
     "fast-json-stable-stringify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
-      "dev": true
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -10654,8 +10651,7 @@
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -17094,8 +17090,7 @@
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "pupa": {
       "version": "2.0.1",
@@ -20402,7 +20397,6 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
       "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
-      "dev": true,
       "requires": {
         "punycode": "^2.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "webpack-dev-server": "^3.11.0"
   },
   "dependencies": {
+    "ajv": "^7.12.4",
     "express": "^4.17.1",
     "prop-types": "^15.7.2",
     "react": "^16.13.1",

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "webpack-dev-server": "^3.11.0"
   },
   "dependencies": {
-    "ajv": "^7.12.4",
+    "ajv": "^6.12.4",
     "express": "^4.17.1",
     "prop-types": "^15.7.2",
     "react": "^16.13.1",

--- a/src/server/WSExecutor.js
+++ b/src/server/WSExecutor.js
@@ -35,6 +35,34 @@ class WSExecutor extends WSClientListener {
     super(data);
     this.send = send;
   }
+
+  sendMessage(message, ...args) {
+    const payload = {
+      data: { ...message },
+      success: true,
+    };
+    return this.send(JSON.stringify(payload), ...args);
+  }
+
+  sendErrors(errors, ...args) {
+    const payload = {
+      errors: Array.isArray(errors) ? errors : [errors],
+      success: false,
+    };
+    return this.send(JSON.stringify(payload), ...args);
+  }
+
+  /**
+   * JSON error response generator
+   * for the case of validation error.
+   */
+  sendValidationError(e) {
+    this.sendErrors({
+      title: 'The message is invalid',
+      detail: e,
+    });
+    this.socket.close();
+  }
 }
 
 module.exports = WSExecutor;

--- a/src/server/WSTaskServer.js
+++ b/src/server/WSTaskServer.js
@@ -25,7 +25,7 @@ const WebSocket = require('ws');
 const Logger = require('./Logger');
 const WSObserver = require('./WSObserver');
 
-const MAX_PAYLOAD_KB = 5;
+const MAX_PAYLOAD_KB = 10;
 const MAX_PAYLOAD = Math.round(MAX_PAYLOAD_KB * (2 ** 10));
 
 /**


### PR DESCRIPTION
- Add `ajv` for JSON parsing
- Validate incoming message if JSON schema is available
- Add methods to Executor to send JSON messages and errors
- Increase maximal payload because JSON messages are longer