### PR TITLE
Fix #108: Observer can cause fatal server error by simply ignoring the socket close

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,11 @@ Added
 
 - Server-side support of JSON messages.
 
+Fixed
+-----
+
+- Observer should not cause server failure by ignoring the socket close.
+
 `0.1.1`_ - 2020-08-23
 =====================
 

--- a/src/server/WSClientListener.js
+++ b/src/server/WSClientListener.js
@@ -83,8 +83,15 @@ class WSClientListener {
   validateSchema() {
   }
 
+  /**
+   * Terminate socket in order to avoid an error
+   * when a client ignores the close request
+   * and sends a message.
+   * The server may try to remove it from the pool
+   * but this causes an error.
+   */
   close() {
-    this.socket.close();
+    this.socket.terminate();
   }
 
   _registerListeners(socket) {


### PR DESCRIPTION
Terminate socket (instead of gracefully closing it) in order to avoid an error when a client ignores the close request and then sends a message. The server may try to remove it from the pool but this causes an error.