### PR TITLE
Fix #111: Build fails because of `autoprefixer` update

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,11 @@ and this project adheres to `Semantic Versioning`_.
 Unreleased_
 ===========
 
+Fixed
+-----
+
+- Build failed with new ``autoprefixer`` (version ``10``).
+
 `0.2.0`_ - 2020-09-19
 =====================
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pattern-recognition-server",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3086,55 +3086,18 @@
       "dev": true
     },
     "autoprefixer": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.0.0.tgz",
-      "integrity": "sha512-rFlVYthz6Iw0LhEYryiGGyjTGofebWie3ydvtqTCJiwWe+z6y8H35b4cadYbOUcYlP495TNeVktW+ZZqxbPW4Q==",
+      "version": "9.8.6",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.8.6.tgz",
+      "integrity": "sha512-XrvP4VVHdRBCdX1S3WXVD8+RyG9qeb1D5Sn1DeLiG2xfSpzellk5k54xbUERJ3M5DggQxes39UGOTP8CFrEGbg==",
       "dev": true,
       "requires": {
-        "browserslist": "^4.14.2",
-        "caniuse-lite": "^1.0.30001131",
+        "browserslist": "^4.12.0",
+        "caniuse-lite": "^1.0.30001109",
         "colorette": "^1.2.1",
         "normalize-range": "^0.1.2",
         "num2fraction": "^1.2.2",
+        "postcss": "^7.0.32",
         "postcss-value-parser": "^4.1.0"
-      },
-      "dependencies": {
-        "browserslist": {
-          "version": "4.14.3",
-          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.14.3.tgz",
-          "integrity": "sha512-GcZPC5+YqyPO4SFnz48/B0YaCwS47Q9iPChRGi6t7HhflKBcINzFrJvRfC+jp30sRMKxF+d4EHGs27Z0XP1NaQ==",
-          "dev": true,
-          "requires": {
-            "caniuse-lite": "^1.0.30001131",
-            "electron-to-chromium": "^1.3.570",
-            "escalade": "^3.1.0",
-            "node-releases": "^1.1.61"
-          }
-        },
-        "caniuse-lite": {
-          "version": "1.0.30001132",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001132.tgz",
-          "integrity": "sha512-zk5FXbnsmHa0Ktc/NOZJRr+ilXva+2KFJuRiQfnjkxJfV/7DYP5C27lSQF++/veCUzVWE5xecZnSBJjf6fSwJA==",
-          "dev": true
-        },
-        "electron-to-chromium": {
-          "version": "1.3.570",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.570.tgz",
-          "integrity": "sha512-Y6OCoVQgFQBP5py6A/06+yWxUZHDlNr/gNDGatjH8AZqXl8X0tE4LfjLJsXGz/JmWJz8a6K7bR1k+QzZ+k//fg==",
-          "dev": true
-        },
-        "escalade": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.0.tgz",
-          "integrity": "sha512-mAk+hPSO8fLDkhV7V0dXazH5pDc6MrjBTPyD3VeKzxnVFjH1MIxbCdqGZB9O8+EwWakZs3ZCbDS4IpRt79V1ig==",
-          "dev": true
-        },
-        "node-releases": {
-          "version": "1.1.61",
-          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.61.tgz",
-          "integrity": "sha512-DD5vebQLg8jLCOzwupn954fbIiZht05DAZs0k2u8NStSe6h9XdsuIQL8hSRKYiU8WUQRznmSDrKGbv3ObOmC7g==",
-          "dev": true
-        }
       }
     },
     "aws-sign2": {

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "@babel/plugin-transform-runtime": "^7.11.5",
     "@babel/preset-env": "^7.11.5",
     "@babel/preset-react": "^7.10.4",
-    "autoprefixer": "^10.0.0",
+    "autoprefixer": "^9.0.0",
     "babel-eslint": "^10.1.0",
     "babel-loader": "^8.1.0",
     "css-loader": "^4.3.0",


### PR DESCRIPTION
Downgrade `autoprefixer` to `^9.0.0`